### PR TITLE
Removed .unwrap() on test

### DIFF
--- a/src/tests/chunk_type_tests.rs
+++ b/src/tests/chunk_type_tests.rs
@@ -78,7 +78,7 @@ mod tests {
         let chunk = ChunkType::from_str("Rust").unwrap();
         assert!(!chunk.is_valid());
 
-        let chunk = ChunkType::from_str("Ru1t").unwrap();
+        let chunk = ChunkType::from_str("Ru1t");
         assert!(chunk.is_err());
     }
 


### PR DESCRIPTION
I think the chunk still needs to be a Result type for .is_err() to work.