### PR TITLE
Use `STANDARD_HEADER` constant everywhere

### DIFF
--- a/src/tests/png_tests.rs
+++ b/src/tests/png_tests.rs
@@ -152,7 +152,7 @@ mod tests {
             .flat_map(|chunk| chunk.as_bytes())
             .collect();
 
-        let bytes: Vec<u8> = Png::EXPECTED_HEADER
+        let bytes: Vec<u8> = Png::STANDARD_HEADER
             .iter()
             .chain(chunk_bytes.iter())
             .copied()


### PR DESCRIPTION
It's `STANDARD_HEADER` everywhere else: https://github.com/picklenerd/pngme_book/search?q=STANDARD_HEADER&unscoped_q=STANDARD_HEADER