### PR TITLE
Update test_as_bytes with clippy feedback

### DIFF
--- a/src/tests/png_tests.rs
+++ b/src/tests/png_tests.rs
@@ -141,7 +141,7 @@ mod tests {
     fn test_as_bytes() {
         let png = Png::try_from(&PNG_FILE[..]).unwrap();
         let actual = png.as_bytes();
-        let expected: Vec<u8> = PNG_FILE.iter().copied().collect();
+        let expected: Vec<u8> = PNG_FILE.to_vec();
         assert_eq!(actual, expected);
     }
 


### PR DESCRIPTION
Cargo clippy suggests to simplify the code:

```
called `iter().copied().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and more readable
for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_cloned_collect
`#[warn(clippy::iter_cloned_collect)]` on by default
```