### PR TITLE
Update testing_chunks with clippy feedback

### DIFF
--- a/src/tests/png_tests.rs
+++ b/src/tests/png_tests.rs
@@ -7,13 +7,11 @@ mod tests {
     use std::convert::TryFrom;
 
     fn testing_chunks() -> Vec<Chunk> {
-        let mut chunks = Vec::new();
-
-        chunks.push(chunk_from_strings("FrSt", "I am the first chunk").unwrap());
-        chunks.push(chunk_from_strings("miDl", "I am another chunk").unwrap());
-        chunks.push(chunk_from_strings("LASt", "I am the last chunk").unwrap());
-
-        chunks
+        vec![
+            chunk_from_strings("FrSt", "I am the first chunk").unwrap(),
+            chunk_from_strings("miDl", "I am another chunk").unwrap(),
+            chunk_from_strings("LASt", "I am the last chunk").unwrap(),
+        ]
     }
 
     fn testing_png() -> Png {


### PR DESCRIPTION
Similar to https://github.com/picklenerd/pngme_book/commit/483ecd794787f17ad4846bae75e20816ea845521 clippy suggests to simplify the code:
```
calls to `push` immediately after creation
for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#vec_init_then_push
`#[warn(clippy::vec_init_then_push)]` on by default

consider using the `vec![]` macro: `let chunks = vec![..];`
```

A small change so the student is not distracted by clippy's warning about it.