### PR TITLE
Fix PNG header in test_invalid_chunk

### DIFF
--- a/code/src/chunk.rs
+++ b/code/src/chunk.rs
@@ -13,12 +13,6 @@ pub struct Chunk {
 }
 
 impl Chunk {
-    /// Creates a new chunk from a validated `ChunkType` and some data.
-    /// The length and CRC will be computed automatically.
-    pub fn new(chunk_type: ChunkType, data: Vec<u8>) -> Self {
-        todo!()
-    }
-
     /// The length of the data portion of this chunk.
     pub fn length(&self) -> u32 {
         todo!()
@@ -79,14 +73,34 @@ impl fmt::Display for Chunk {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::chunk_type::ChunkType;
     use std::str::FromStr;
 
     fn testing_chunk() -> Chunk {
-        let chunk_type = ChunkType::from_str("RuSt").unwrap();
-        let data: Vec<u8> = "This is where your secret message will be!"
-            .bytes()
+        let data_length: u32 = 42;
+        let chunk_type = "RuSt".as_bytes();
+        let message_bytes = "This is where your secret message will be!".as_bytes();
+        let crc: u32 = 2882656334;
+
+        let chunk_data: Vec<u8> = data_length
+            .to_be_bytes()
+            .iter()
+            .chain(chunk_type.iter())
+            .chain(message_bytes.iter())
+            .chain(crc.to_be_bytes().iter())
+            .copied()
             .collect();
-        Chunk::new(chunk_type, data)
+        
+        Chunk::try_from(chunk_data.as_ref()).unwrap()
+    }
+
+    #[test]
+    fn test_new_chunk() {
+        let chunk_type = ChunkType::from_str("RuSt").unwrap();
+        let data = "This is where your secret message will be!".as_bytes().to_vec();
+        let chunk = Chunk::new(chunk_type, data);
+        assert_eq!(chunk.length(), 42);
+        assert_eq!(chunk.crc(), 2882656334);
     }
 
     #[test]
@@ -161,5 +175,26 @@ mod tests {
         let chunk = Chunk::try_from(chunk_data.as_ref());
 
         assert!(chunk.is_err());
+    }
+
+    #[test]
+    pub fn test_chunk_trait_impls() {
+        let data_length: u32 = 42;
+        let chunk_type = "RuSt".as_bytes();
+        let message_bytes = "This is where your secret message will be!".as_bytes();
+        let crc: u32 = 2882656334;
+
+        let chunk_data: Vec<u8> = data_length
+            .to_be_bytes()
+            .iter()
+            .chain(chunk_type.iter())
+            .chain(message_bytes.iter())
+            .chain(crc.to_be_bytes().iter())
+            .copied()
+            .collect();
+        
+        let chunk: Chunk = TryFrom::try_from(chunk_data.as_ref()).unwrap();
+        
+        let _chunk_string = format!("{}", chunk);
     }
 }

--- a/code/src/chunk_type.rs
+++ b/code/src/chunk_type.rs
@@ -13,7 +13,7 @@ pub struct ChunkType {
 
 impl ChunkType {
     /// Returns the raw bytes contained in this chunk
-    pub fn bytes(&self) -> &[u8; 4] {
+    pub fn bytes(&self) -> [u8; 4] {
         todo!()
     }
 
@@ -74,10 +74,12 @@ impl FromStr for ChunkType {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::convert::TryFrom;
+    use std::str::FromStr;
 
     #[test]
     pub fn test_chunk_type_from_bytes() {
-        let expected = &[82, 117, 83, 116];
+        let expected = [82, 117, 83, 116];
         let actual = ChunkType::try_from([82, 117, 83, 116]).unwrap();
 
         assert_eq!(expected, actual.bytes());
@@ -157,5 +159,13 @@ mod tests {
     pub fn test_chunk_type_string() {
         let chunk = ChunkType::from_str("RuSt").unwrap();
         assert_eq!(&chunk.to_string(), "RuSt");
+    }
+
+    #[test]
+    pub fn test_chunk_type_trait_impls() {
+        let chunk_type_1: ChunkType = TryFrom::try_from([82, 117, 83, 116]).unwrap();
+        let chunk_type_2: ChunkType = FromStr::from_str("RuSt").unwrap();
+        let _chunk_string = format!("{}", chunk_type_1);
+        let _are_chunks_equal = chunk_type_1 == chunk_type_2;
     }
 }

--- a/code/src/main.rs
+++ b/code/src/main.rs
@@ -2,21 +2,11 @@ mod args;
 mod chunk;
 mod chunk_type;
 mod commands;
-pub mod png;
-
-use crate::args::PngMeArgs;
-use crate::commands::{decode, encode, print_chunks, remove};
+mod png;
 
 pub type Error = Box<dyn std::error::Error>;
 pub type Result<T> = std::result::Result<T, Error>;
 
 fn main() -> Result<()> {
-    let args = todo!();
-
-    match args {
-        PngMeArgs::Encode(encode_args) => encode(encode_args),
-        PngMeArgs::Decode(decode_args) => decode(decode_args),
-        PngMeArgs::Remove(remove_args) => remove(remove_args),
-        PngMeArgs::Print(print_args) => print_chunks(print_args),
-    }
+    todo!()
 }

--- a/code/src/png.rs
+++ b/code/src/png.rs
@@ -81,10 +81,10 @@ impl fmt::Display for Png {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chunk_type::ChunkType;
     use crate::chunk::Chunk;
-    use std::str::FromStr;
+    use crate::chunk_type::ChunkType;
     use std::convert::TryFrom;
+    use std::str::FromStr;
 
     fn testing_chunks() -> Vec<Chunk> {
         vec![
@@ -169,11 +169,16 @@ mod tests {
 
         chunk_bytes.append(&mut bad_chunk);
 
-        let png = Png::try_from(chunk_bytes.as_ref());
+        let bytes: Vec<u8> = Png::STANDARD_HEADER
+            .iter()
+            .chain(chunk_bytes.iter())
+            .copied()
+            .collect();
+
+        let png = Png::try_from(bytes.as_ref());
 
         assert!(png.is_err());
     }
-
 
     #[test]
     fn test_list_chunks() {
@@ -188,7 +193,6 @@ mod tests {
         let chunk = png.chunk_by_type("FrSt").unwrap();
         assert_eq!(&chunk.chunk_type().to_string(), "FrSt");
         assert_eq!(&chunk.data_as_string().unwrap(), "I am the first chunk");
-
     }
 
     #[test]

--- a/src/tests/png_tests.rs
+++ b/src/tests/png_tests.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chunk_type::ChunkType;
     use crate::chunk::Chunk;
-    use std::str::FromStr;
+    use crate::chunk_type::ChunkType;
     use std::convert::TryFrom;
+    use std::str::FromStr;
 
     fn testing_chunks() -> Vec<Chunk> {
         vec![
@@ -89,11 +89,16 @@ mod tests {
 
         chunk_bytes.append(&mut bad_chunk);
 
-        let png = Png::try_from(chunk_bytes.as_ref());
+        let bytes: Vec<u8> = Png::STANDARD_HEADER
+            .iter()
+            .chain(chunk_bytes.iter())
+            .copied()
+            .collect();
+
+        let png = Png::try_from(bytes.as_ref());
 
         assert!(png.is_err());
     }
-
 
     #[test]
     fn test_list_chunks() {
@@ -108,7 +113,6 @@ mod tests {
         let chunk = png.chunk_by_type("FrSt").unwrap();
         assert_eq!(&chunk.chunk_type().to_string(), "FrSt");
         assert_eq!(&chunk.data_as_string().unwrap(), "I am the first chunk");
-
     }
 
     #[test]

--- a/util/update_code
+++ b/util/update_code
@@ -1,0 +1,38 @@
+#! /bin/sh
+
+code_src=${1:-code/src}
+
+[ -d ".git" -a -r "book.toml" -a -r "src/tests/chunk_type_tests.rs" ] \
+  || { echo "Run this from the top level of the sources" >&2; exit 2; }
+
+[ -r "$code_src/chunk_type.rs" ] \
+  || { echo "Can't find sources in '$code_src'" >&2; exit 2; }
+
+if [ $# -eq 0 ]; then
+  for stubs in src/stubs/*_full.rs src/stubs/*_stubs.rs; do
+    base=$(basename "$stubs")
+    base=${base%_full.rs}
+    base=${base%_stubs.rs}
+    out=$code_src/$base.rs
+    echo "Setting $out to $stubs"
+    cp "$stubs" "$out"
+    if [ -r src/tests/${base}_tests.rs ]; then
+      printf "\n%s\n" '#[cfg(test)]' >> "$out"
+    fi
+  done
+fi
+
+for tests in src/tests/*_tests.rs; do
+  base=$code_src/$(basename "$tests")
+  base=${base%_tests.rs}
+  out=$base.rs
+  echo "Updating $out with $tests"
+  sed -i -n \
+    "
+      /^#\[cfg(test)]/ {
+        r $tests
+        q
+      }
+      p
+    " "$out"
+  done


### PR DESCRIPTION
This is to fix issue #14.

AND it also includes a utility to sync the `src/tests/*_tests.rs` test code to the bottom of the `code/src/*.rs` skeleton code. This will make it easier to maintain.