### PR TITLE
chunk_type: safe-to-copy bit is 0 for critical chunks

### DIFF
--- a/code/src/chunk.rs
+++ b/code/src/chunk.rs
@@ -74,19 +74,21 @@ impl fmt::Display for Chunk {
 mod tests {
     use super::*;
     use crate::chunk_type::ChunkType;
+    const CHUNK_MESSAGE: &str = "This is where your secret message will be!";
+    const CHUNK_DATA_LENGTH: u32 = CHUNK_MESSAGE.len() as u32;
+    const CHUNK_STR: &str = "rUSt";
+    const CHUNK_CRC: u32 = 562223355;
 
     fn testing_chunk() -> Chunk {
-        let data_length: u32 = 42;
-        let chunk_type = "RuSt".as_bytes();
-        let message_bytes = "This is where your secret message will be!".as_bytes();
-        let crc: u32 = 2882656334;
+        let chunk_type = CHUNK_STR.as_bytes();
+        let message_bytes = CHUNK_MESSAGE.as_bytes();
 
-        let chunk_data: Vec<u8> = data_length
+        let chunk_data: Vec<u8> = CHUNK_DATA_LENGTH
             .to_be_bytes()
             .iter()
             .chain(chunk_type.iter())
             .chain(message_bytes.iter())
-            .chain(crc.to_be_bytes().iter())
+            .chain(CHUNK_CRC.to_be_bytes().iter())
             .copied()
             .collect();
         
@@ -95,11 +97,11 @@ mod tests {
 
     #[test]
     fn test_new_chunk() {
-        let chunk_type: ChunkType = "RuSt".parse().unwrap();
-        let data = "This is where your secret message will be!".as_bytes().to_vec();
+        let chunk_type: ChunkType = CHUNK_STR.parse().unwrap();
+        let data = CHUNK_MESSAGE.as_bytes().to_vec();
         let chunk = Chunk::new(chunk_type, data);
-        assert_eq!(chunk.length(), 42);
-        assert_eq!(chunk.crc(), 2882656334);
+        assert_eq!(chunk.length(), CHUNK_DATA_LENGTH);
+        assert_eq!(chunk.crc(), CHUNK_CRC);
     }
 
     #[test]
@@ -111,58 +113,55 @@ mod tests {
     #[test]
     fn test_chunk_type() {
         let chunk = testing_chunk();
-        assert_eq!(chunk.chunk_type().to_string(), String::from("RuSt"));
+        assert_eq!(chunk.chunk_type().to_string(), String::from(CHUNK_STR));
     }
 
     #[test]
     fn test_chunk_string() {
         let chunk = testing_chunk();
         let chunk_string = chunk.data_as_string().unwrap();
-        let expected_chunk_string = String::from("This is where your secret message will be!");
+        let expected_chunk_string = String::from(CHUNK_MESSAGE);
         assert_eq!(chunk_string, expected_chunk_string);
     }
 
     #[test]
     fn test_chunk_crc() {
         let chunk = testing_chunk();
-        assert_eq!(chunk.crc(), 2882656334);
+        assert_eq!(chunk.crc(), CHUNK_CRC);
     }
 
     #[test]
     fn test_valid_chunk_from_bytes() {
-        let data_length: u32 = 42;
-        let chunk_type = "RuSt".as_bytes();
-        let message_bytes = "This is where your secret message will be!".as_bytes();
-        let crc: u32 = 2882656334;
+        let chunk_type = CHUNK_STR.as_bytes();
+        let message_bytes = CHUNK_MESSAGE.as_bytes();
 
-        let chunk_data: Vec<u8> = data_length
+        let chunk_data: Vec<u8> = CHUNK_DATA_LENGTH
             .to_be_bytes()
             .iter()
             .chain(chunk_type.iter())
             .chain(message_bytes.iter())
-            .chain(crc.to_be_bytes().iter())
+            .chain(CHUNK_CRC.to_be_bytes().iter())
             .copied()
             .collect();
 
         let chunk = Chunk::try_from(chunk_data.as_ref()).unwrap();
 
         let chunk_string = chunk.data_as_string().unwrap();
-        let expected_chunk_string = String::from("This is where your secret message will be!");
+        let expected_chunk_string = String::from(CHUNK_MESSAGE);
 
         assert_eq!(chunk.length(), 42);
-        assert_eq!(chunk.chunk_type().to_string(), String::from("RuSt"));
+        assert_eq!(chunk.chunk_type().to_string(), String::from(CHUNK_STR));
         assert_eq!(chunk_string, expected_chunk_string);
-        assert_eq!(chunk.crc(), 2882656334);
+        assert_eq!(chunk.crc(), CHUNK_CRC);
     }
 
     #[test]
     fn test_invalid_chunk_from_bytes() {
-        let data_length: u32 = 42;
-        let chunk_type = "RuSt".as_bytes();
-        let message_bytes = "This is where your secret message will be!".as_bytes();
-        let crc: u32 = 2882656333;
+        let chunk_type = CHUNK_STR.as_bytes();
+        let message_bytes = CHUNK_MESSAGE.as_bytes();
+        let crc: u32 = CHUNK_CRC - 1;
 
-        let chunk_data: Vec<u8> = data_length
+        let chunk_data: Vec<u8> = CHUNK_DATA_LENGTH
             .to_be_bytes()
             .iter()
             .chain(chunk_type.iter())
@@ -178,17 +177,15 @@ mod tests {
 
     #[test]
     pub fn test_chunk_trait_impls() {
-        let data_length: u32 = 42;
-        let chunk_type = "RuSt".as_bytes();
-        let message_bytes = "This is where your secret message will be!".as_bytes();
-        let crc: u32 = 2882656334;
+        let chunk_type = CHUNK_STR.as_bytes();
+        let message_bytes = CHUNK_MESSAGE.as_bytes();
 
-        let chunk_data: Vec<u8> = data_length
+        let chunk_data: Vec<u8> = CHUNK_DATA_LENGTH
             .to_be_bytes()
             .iter()
             .chain(chunk_type.iter())
             .chain(message_bytes.iter())
-            .chain(crc.to_be_bytes().iter())
+            .chain(CHUNK_CRC.to_be_bytes().iter())
             .copied()
             .collect();
         

--- a/code/src/chunk.rs
+++ b/code/src/chunk.rs
@@ -74,7 +74,6 @@ impl fmt::Display for Chunk {
 mod tests {
     use super::*;
     use crate::chunk_type::ChunkType;
-    use std::str::FromStr;
 
     fn testing_chunk() -> Chunk {
         let data_length: u32 = 42;
@@ -96,7 +95,7 @@ mod tests {
 
     #[test]
     fn test_new_chunk() {
-        let chunk_type = ChunkType::from_str("RuSt").unwrap();
+        let chunk_type: ChunkType = "RuSt".parse().unwrap();
         let data = "This is where your secret message will be!".as_bytes().to_vec();
         let chunk = Chunk::new(chunk_type, data);
         assert_eq!(chunk.length(), 42);

--- a/code/src/chunk.rs
+++ b/code/src/chunk.rs
@@ -13,12 +13,6 @@ pub struct Chunk {
 }
 
 impl Chunk {
-    /// Creates a new chunk from a validated `ChunkType` and some data.
-    /// The length and CRC will be computed automatically.
-    pub fn new(chunk_type: ChunkType, data: Vec<u8>) -> Self {
-        todo!()
-    }
-
     /// The length of the data portion of this chunk.
     pub fn length(&self) -> u32 {
         todo!()
@@ -79,14 +73,34 @@ impl fmt::Display for Chunk {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::chunk_type::ChunkType;
     use std::str::FromStr;
 
     fn testing_chunk() -> Chunk {
-        let chunk_type = ChunkType::from_str("RuSt").unwrap();
-        let data: Vec<u8> = "This is where your secret message will be!"
-            .bytes()
+        let data_length: u32 = 42;
+        let chunk_type = "RuSt".as_bytes();
+        let message_bytes = "This is where your secret message will be!".as_bytes();
+        let crc: u32 = 2882656334;
+
+        let chunk_data: Vec<u8> = data_length
+            .to_be_bytes()
+            .iter()
+            .chain(chunk_type.iter())
+            .chain(message_bytes.iter())
+            .chain(crc.to_be_bytes().iter())
+            .copied()
             .collect();
-        Chunk::new(chunk_type, data)
+        
+        Chunk::try_from(chunk_data.as_ref()).unwrap()
+    }
+
+    #[test]
+    fn test_new_chunk() {
+        let chunk_type = ChunkType::from_str("RuSt").unwrap();
+        let data = "This is where your secret message will be!".as_bytes().to_vec();
+        let chunk = Chunk::new(chunk_type, data);
+        assert_eq!(chunk.length(), 42);
+        assert_eq!(chunk.crc(), 2882656334);
     }
 
     #[test]
@@ -161,5 +175,26 @@ mod tests {
         let chunk = Chunk::try_from(chunk_data.as_ref());
 
         assert!(chunk.is_err());
+    }
+
+    #[test]
+    pub fn test_chunk_trait_impls() {
+        let data_length: u32 = 42;
+        let chunk_type = "RuSt".as_bytes();
+        let message_bytes = "This is where your secret message will be!".as_bytes();
+        let crc: u32 = 2882656334;
+
+        let chunk_data: Vec<u8> = data_length
+            .to_be_bytes()
+            .iter()
+            .chain(chunk_type.iter())
+            .chain(message_bytes.iter())
+            .chain(crc.to_be_bytes().iter())
+            .copied()
+            .collect();
+        
+        let chunk: Chunk = TryFrom::try_from(chunk_data.as_ref()).unwrap();
+        
+        let _chunk_string = format!("{}", chunk);
     }
 }

--- a/code/src/chunk_type.rs
+++ b/code/src/chunk_type.rs
@@ -77,22 +77,22 @@ mod tests {
 
     #[test]
     pub fn test_chunk_type_from_bytes() {
-        let expected = [82, 117, 83, 116];
-        let actual = ChunkType::try_from([82, 117, 83, 116]).unwrap();
+        let expected = [114, 85, 83, 116];
+        let actual = ChunkType::try_from(expected).unwrap();
 
         assert_eq!(expected, actual.bytes());
     }
 
     #[test]
     pub fn test_chunk_type_from_str() {
-        let expected = ChunkType::try_from([82, 117, 83, 116]).unwrap();
-        let actual: ChunkType = "RuSt".parse().unwrap();
+        let expected = ChunkType::try_from([114, 85, 83, 116]).unwrap();
+        let actual: ChunkType = "rUSt".parse().unwrap();
         assert_eq!(expected, actual);
     }
 
     #[test]
     pub fn test_chunk_type_is_critical() {
-        let chunk: ChunkType = "RuSt".parse().unwrap();
+        let chunk: ChunkType = "RUSt".parse().unwrap();
         assert!(chunk.is_critical());
     }
 
@@ -104,19 +104,19 @@ mod tests {
 
     #[test]
     pub fn test_chunk_type_is_public() {
-        let chunk: ChunkType = "RUSt".parse().unwrap();
+        let chunk: ChunkType = "rUSt".parse().unwrap();
         assert!(chunk.is_public());
     }
 
     #[test]
     pub fn test_chunk_type_is_not_public() {
-        let chunk: ChunkType = "RuSt".parse().unwrap();
+        let chunk: ChunkType = "ruSt".parse().unwrap();
         assert!(!chunk.is_public());
     }
 
     #[test]
     pub fn test_chunk_type_is_reserved_bit_valid() {
-        let chunk: ChunkType = "RuSt".parse().unwrap();
+        let chunk: ChunkType = "rUSt".parse().unwrap();
         assert!(chunk.is_reserved_bit_valid());
     }
 
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     pub fn test_chunk_type_is_safe_to_copy() {
-        let chunk: ChunkType = "RuSt".parse().unwrap();
+        let chunk: ChunkType = "rUSt".parse().unwrap();
         assert!(chunk.is_safe_to_copy());
     }
 
@@ -140,29 +140,41 @@ mod tests {
 
     #[test]
     pub fn test_valid_chunk_is_valid() {
-        let chunk: ChunkType = "RuSt".parse().unwrap();
+        let chunk: ChunkType = "rUSt".parse().unwrap();
+        assert!(chunk.is_valid());
+
+        let chunk: ChunkType = "RuST".parse().unwrap();
         assert!(chunk.is_valid());
     }
 
     #[test]
-    pub fn test_invalid_chunk_is_valid() {
-        let chunk: ChunkType = "Rust".parse().unwrap();
-        assert!(!chunk.is_valid());
-
-        let chunk: Result<ChunkType> = "Ru1t".parse();
+    pub fn test_invalid_character() {
+        let chunk: Result<ChunkType> = "r1St".parse();
         assert!(chunk.is_err());
     }
 
     #[test]
-    pub fn test_chunk_type_string() {
+    pub fn test_invalid_reserved() {
+        let chunk: ChunkType = "rUst".parse().unwrap();
+        assert!(!chunk.is_valid());
+    }
+
+    #[test]
+    pub fn test_invalid_safetocopy() {
         let chunk: ChunkType = "RuSt".parse().unwrap();
-        assert_eq!(&chunk.to_string(), "RuSt");
+        assert!(!chunk.is_valid());
+    }
+
+    #[test]
+    pub fn test_chunk_type_string() {
+        let chunk: ChunkType = "rUSt".parse().unwrap();
+        assert_eq!(&chunk.to_string(), "rUSt");
     }
 
     #[test]
     pub fn test_chunk_type_trait_impls() {
         let chunk_type_1: ChunkType = [82, 117, 83, 116].try_into().unwrap();
-        let chunk_type_2: ChunkType = "RuSt".parse().unwrap();
+        let chunk_type_2: ChunkType = "rUSt".parse().unwrap();
         let _chunk_string = format!("{}", chunk_type_1);
         let _are_chunks_equal = chunk_type_1 == chunk_type_2;
     }

--- a/code/src/chunk_type.rs
+++ b/code/src/chunk_type.rs
@@ -13,7 +13,7 @@ pub struct ChunkType {
 
 impl ChunkType {
     /// Returns the raw bytes contained in this chunk
-    pub fn bytes(&self) -> &[u8; 4] {
+    pub fn bytes(&self) -> [u8; 4] {
         todo!()
     }
 
@@ -74,10 +74,12 @@ impl FromStr for ChunkType {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::convert::TryFrom;
+    use std::str::FromStr;
 
     #[test]
     pub fn test_chunk_type_from_bytes() {
-        let expected = &[82, 117, 83, 116];
+        let expected = [82, 117, 83, 116];
         let actual = ChunkType::try_from([82, 117, 83, 116]).unwrap();
 
         assert_eq!(expected, actual.bytes());
@@ -157,5 +159,13 @@ mod tests {
     pub fn test_chunk_type_string() {
         let chunk = ChunkType::from_str("RuSt").unwrap();
         assert_eq!(&chunk.to_string(), "RuSt");
+    }
+
+    #[test]
+    pub fn test_chunk_type_trait_impls() {
+        let chunk_type_1: ChunkType = TryFrom::try_from([82, 117, 83, 116]).unwrap();
+        let chunk_type_2: ChunkType = FromStr::from_str("RuSt").unwrap();
+        let _chunk_string = format!("{}", chunk_type_1);
+        let _are_chunks_equal = chunk_type_1 == chunk_type_2;
     }
 }

--- a/code/src/chunk_type.rs
+++ b/code/src/chunk_type.rs
@@ -74,8 +74,6 @@ impl FromStr for ChunkType {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::convert::TryFrom;
-    use std::str::FromStr;
 
     #[test]
     pub fn test_chunk_type_from_bytes() {
@@ -88,83 +86,83 @@ mod tests {
     #[test]
     pub fn test_chunk_type_from_str() {
         let expected = ChunkType::try_from([82, 117, 83, 116]).unwrap();
-        let actual = ChunkType::from_str("RuSt").unwrap();
+        let actual: ChunkType = "RuSt".parse().unwrap();
         assert_eq!(expected, actual);
     }
 
     #[test]
     pub fn test_chunk_type_is_critical() {
-        let chunk = ChunkType::from_str("RuSt").unwrap();
+        let chunk: ChunkType = "RuSt".parse().unwrap();
         assert!(chunk.is_critical());
     }
 
     #[test]
     pub fn test_chunk_type_is_not_critical() {
-        let chunk = ChunkType::from_str("ruSt").unwrap();
+        let chunk: ChunkType = "ruSt".parse().unwrap();
         assert!(!chunk.is_critical());
     }
 
     #[test]
     pub fn test_chunk_type_is_public() {
-        let chunk = ChunkType::from_str("RUSt").unwrap();
+        let chunk: ChunkType = "RUSt".parse().unwrap();
         assert!(chunk.is_public());
     }
 
     #[test]
     pub fn test_chunk_type_is_not_public() {
-        let chunk = ChunkType::from_str("RuSt").unwrap();
+        let chunk: ChunkType = "RuSt".parse().unwrap();
         assert!(!chunk.is_public());
     }
 
     #[test]
     pub fn test_chunk_type_is_reserved_bit_valid() {
-        let chunk = ChunkType::from_str("RuSt").unwrap();
+        let chunk: ChunkType = "RuSt".parse().unwrap();
         assert!(chunk.is_reserved_bit_valid());
     }
 
     #[test]
     pub fn test_chunk_type_is_reserved_bit_invalid() {
-        let chunk = ChunkType::from_str("Rust").unwrap();
+        let chunk: ChunkType = "Rust".parse().unwrap();
         assert!(!chunk.is_reserved_bit_valid());
     }
 
     #[test]
     pub fn test_chunk_type_is_safe_to_copy() {
-        let chunk = ChunkType::from_str("RuSt").unwrap();
+        let chunk: ChunkType = "RuSt".parse().unwrap();
         assert!(chunk.is_safe_to_copy());
     }
 
     #[test]
     pub fn test_chunk_type_is_unsafe_to_copy() {
-        let chunk = ChunkType::from_str("RuST").unwrap();
+        let chunk: ChunkType = "RuST".parse().unwrap();
         assert!(!chunk.is_safe_to_copy());
     }
 
     #[test]
     pub fn test_valid_chunk_is_valid() {
-        let chunk = ChunkType::from_str("RuSt").unwrap();
+        let chunk: ChunkType = "RuSt".parse().unwrap();
         assert!(chunk.is_valid());
     }
 
     #[test]
     pub fn test_invalid_chunk_is_valid() {
-        let chunk = ChunkType::from_str("Rust").unwrap();
+        let chunk: ChunkType = "Rust".parse().unwrap();
         assert!(!chunk.is_valid());
 
-        let chunk = ChunkType::from_str("Ru1t");
+        let chunk: Result<ChunkType> = "Ru1t".parse();
         assert!(chunk.is_err());
     }
 
     #[test]
     pub fn test_chunk_type_string() {
-        let chunk = ChunkType::from_str("RuSt").unwrap();
+        let chunk: ChunkType = "RuSt".parse().unwrap();
         assert_eq!(&chunk.to_string(), "RuSt");
     }
 
     #[test]
     pub fn test_chunk_type_trait_impls() {
-        let chunk_type_1: ChunkType = TryFrom::try_from([82, 117, 83, 116]).unwrap();
-        let chunk_type_2: ChunkType = FromStr::from_str("RuSt").unwrap();
+        let chunk_type_1: ChunkType = [82, 117, 83, 116].try_into().unwrap();
+        let chunk_type_2: ChunkType = "RuSt".parse().unwrap();
         let _chunk_string = format!("{}", chunk_type_1);
         let _are_chunks_equal = chunk_type_1 == chunk_type_2;
     }

--- a/code/src/commands.rs
+++ b/code/src/commands.rs
@@ -1,6 +1,5 @@
 use std::convert::TryFrom;
 use std::fs;
-use std::str::FromStr;
 
 use crate::{Error, Result};
 use crate::args::{DecodeArgs, EncodeArgs, PrintArgs, RemoveArgs};

--- a/code/src/main.rs
+++ b/code/src/main.rs
@@ -2,21 +2,11 @@ mod args;
 mod chunk;
 mod chunk_type;
 mod commands;
-pub mod png;
-
-use crate::args::PngMeArgs;
-use crate::commands::{decode, encode, print_chunks, remove};
+mod png;
 
 pub type Error = Box<dyn std::error::Error>;
 pub type Result<T> = std::result::Result<T, Error>;
 
 fn main() -> Result<()> {
-    let args = todo!();
-
-    match args {
-        PngMeArgs::Encode(encode_args) => encode(encode_args),
-        PngMeArgs::Decode(decode_args) => decode(decode_args),
-        PngMeArgs::Remove(remove_args) => remove(remove_args),
-        PngMeArgs::Print(print_args) => print_chunks(print_args),
-    }
+    todo!()
 }

--- a/code/src/png.rs
+++ b/code/src/png.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use std::fs;
 use std::io::{BufReader, Read};
 use std::path::Path;
-use std::str::FromStr;
 
 use crate::{Error, Result};
 use crate::chunk::Chunk;
@@ -83,8 +82,6 @@ mod tests {
     use super::*;
     use crate::chunk::Chunk;
     use crate::chunk_type::ChunkType;
-    use std::convert::TryFrom;
-    use std::str::FromStr;
 
     fn testing_chunks() -> Vec<Chunk> {
         vec![
@@ -100,9 +97,7 @@ mod tests {
     }
 
     fn chunk_from_strings(chunk_type: &str, data: &str) -> Result<Chunk> {
-        use std::str::FromStr;
-
-        let chunk_type = ChunkType::from_str(chunk_type)?;
+        let chunk_type: ChunkType = chunk_type.parse()?;
         let data: Vec<u8> = data.bytes().collect();
 
         Ok(Chunk::new(chunk_type, data))
@@ -240,7 +235,8 @@ mod tests {
             .copied()
             .collect();
 
-        let png: Png = TryFrom::try_from(bytes.as_ref()).unwrap();
+        let bytes_ref: &[u8] = bytes.as_ref();
+        let png: Png = bytes_ref.try_into().unwrap();
 
         let _png_string = format!("{}", png);
     }

--- a/code/src/png.rs
+++ b/code/src/png.rs
@@ -81,10 +81,10 @@ impl fmt::Display for Png {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chunk_type::ChunkType;
     use crate::chunk::Chunk;
-    use std::str::FromStr;
+    use crate::chunk_type::ChunkType;
     use std::convert::TryFrom;
+    use std::str::FromStr;
 
     fn testing_chunks() -> Vec<Chunk> {
         vec![
@@ -169,11 +169,16 @@ mod tests {
 
         chunk_bytes.append(&mut bad_chunk);
 
-        let png = Png::try_from(chunk_bytes.as_ref());
+        let bytes: Vec<u8> = Png::STANDARD_HEADER
+            .iter()
+            .chain(chunk_bytes.iter())
+            .copied()
+            .collect();
+
+        let png = Png::try_from(bytes.as_ref());
 
         assert!(png.is_err());
     }
-
 
     #[test]
     fn test_list_chunks() {
@@ -188,7 +193,6 @@ mod tests {
         let chunk = png.chunk_by_type("FrSt").unwrap();
         assert_eq!(&chunk.chunk_type().to_string(), "FrSt");
         assert_eq!(&chunk.data_as_string().unwrap(), "I am the first chunk");
-
     }
 
     #[test]

--- a/code/src/png.rs
+++ b/code/src/png.rs
@@ -85,9 +85,9 @@ mod tests {
 
     fn testing_chunks() -> Vec<Chunk> {
         vec![
-            chunk_from_strings("FrSt", "I am the first chunk").unwrap(),
+            chunk_from_strings("FrST", "I am the first chunk").unwrap(),
             chunk_from_strings("miDl", "I am another chunk").unwrap(),
-            chunk_from_strings("LASt", "I am the last chunk").unwrap(),
+            chunk_from_strings("lAST", "I am the last chunk").unwrap(),
         ]
     }
 
@@ -185,26 +185,26 @@ mod tests {
     #[test]
     fn test_chunk_by_type() {
         let png = testing_png();
-        let chunk = png.chunk_by_type("FrSt").unwrap();
-        assert_eq!(&chunk.chunk_type().to_string(), "FrSt");
+        let chunk = png.chunk_by_type("FrST").unwrap();
+        assert_eq!(&chunk.chunk_type().to_string(), "FrST");
         assert_eq!(&chunk.data_as_string().unwrap(), "I am the first chunk");
     }
 
     #[test]
     fn test_append_chunk() {
         let mut png = testing_png();
-        png.append_chunk(chunk_from_strings("TeSt", "Message").unwrap());
-        let chunk = png.chunk_by_type("TeSt").unwrap();
-        assert_eq!(&chunk.chunk_type().to_string(), "TeSt");
+        png.append_chunk(chunk_from_strings("teSt", "Message").unwrap());
+        let chunk = png.chunk_by_type("teSt").unwrap();
+        assert_eq!(&chunk.chunk_type().to_string(), "teSt");
         assert_eq!(&chunk.data_as_string().unwrap(), "Message");
     }
 
     #[test]
     fn test_remove_chunk() {
         let mut png = testing_png();
-        png.append_chunk(chunk_from_strings("TeSt", "Message").unwrap());
-        png.remove_chunk("TeSt").unwrap();
-        let chunk = png.chunk_by_type("TeSt");
+        png.append_chunk(chunk_from_strings("teSt", "Message").unwrap());
+        png.remove_chunk("teSt").unwrap();
+        let chunk = png.chunk_by_type("teSt");
         assert!(chunk.is_none());
     }
 

--- a/src/stubs/commands_stubs.rs
+++ b/src/stubs/commands_stubs.rs
@@ -1,6 +1,5 @@
 use std::convert::TryFrom;
 use std::fs;
-use std::str::FromStr;
 
 use crate::{Error, Result};
 use crate::args::{DecodeArgs, EncodeArgs, PrintArgs, RemoveArgs};

--- a/src/stubs/png_stubs.rs
+++ b/src/stubs/png_stubs.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use std::fs;
 use std::io::{BufReader, Read};
 use std::path::Path;
-use std::str::FromStr;
 
 use crate::{Error, Result};
 use crate::chunk::Chunk;

--- a/src/tests/chunk_tests.rs
+++ b/src/tests/chunk_tests.rs
@@ -2,19 +2,21 @@
 mod tests {
     use super::*;
     use crate::chunk_type::ChunkType;
+    const CHUNK_MESSAGE: &str = "This is where your secret message will be!";
+    const CHUNK_DATA_LENGTH: u32 = CHUNK_MESSAGE.len() as u32;
+    const CHUNK_STR: &str = "rUSt";
+    const CHUNK_CRC: u32 = 562223355;
 
     fn testing_chunk() -> Chunk {
-        let data_length: u32 = 42;
-        let chunk_type = "RuSt".as_bytes();
-        let message_bytes = "This is where your secret message will be!".as_bytes();
-        let crc: u32 = 2882656334;
+        let chunk_type = CHUNK_STR.as_bytes();
+        let message_bytes = CHUNK_MESSAGE.as_bytes();
 
-        let chunk_data: Vec<u8> = data_length
+        let chunk_data: Vec<u8> = CHUNK_DATA_LENGTH
             .to_be_bytes()
             .iter()
             .chain(chunk_type.iter())
             .chain(message_bytes.iter())
-            .chain(crc.to_be_bytes().iter())
+            .chain(CHUNK_CRC.to_be_bytes().iter())
             .copied()
             .collect();
         
@@ -23,11 +25,11 @@ mod tests {
 
     #[test]
     fn test_new_chunk() {
-        let chunk_type: ChunkType = "RuSt".parse().unwrap();
-        let data = "This is where your secret message will be!".as_bytes().to_vec();
+        let chunk_type: ChunkType = CHUNK_STR.parse().unwrap();
+        let data = CHUNK_MESSAGE.as_bytes().to_vec();
         let chunk = Chunk::new(chunk_type, data);
-        assert_eq!(chunk.length(), 42);
-        assert_eq!(chunk.crc(), 2882656334);
+        assert_eq!(chunk.length(), CHUNK_DATA_LENGTH);
+        assert_eq!(chunk.crc(), CHUNK_CRC);
     }
 
     #[test]
@@ -39,58 +41,55 @@ mod tests {
     #[test]
     fn test_chunk_type() {
         let chunk = testing_chunk();
-        assert_eq!(chunk.chunk_type().to_string(), String::from("RuSt"));
+        assert_eq!(chunk.chunk_type().to_string(), String::from(CHUNK_STR));
     }
 
     #[test]
     fn test_chunk_string() {
         let chunk = testing_chunk();
         let chunk_string = chunk.data_as_string().unwrap();
-        let expected_chunk_string = String::from("This is where your secret message will be!");
+        let expected_chunk_string = String::from(CHUNK_MESSAGE);
         assert_eq!(chunk_string, expected_chunk_string);
     }
 
     #[test]
     fn test_chunk_crc() {
         let chunk = testing_chunk();
-        assert_eq!(chunk.crc(), 2882656334);
+        assert_eq!(chunk.crc(), CHUNK_CRC);
     }
 
     #[test]
     fn test_valid_chunk_from_bytes() {
-        let data_length: u32 = 42;
-        let chunk_type = "RuSt".as_bytes();
-        let message_bytes = "This is where your secret message will be!".as_bytes();
-        let crc: u32 = 2882656334;
+        let chunk_type = CHUNK_STR.as_bytes();
+        let message_bytes = CHUNK_MESSAGE.as_bytes();
 
-        let chunk_data: Vec<u8> = data_length
+        let chunk_data: Vec<u8> = CHUNK_DATA_LENGTH
             .to_be_bytes()
             .iter()
             .chain(chunk_type.iter())
             .chain(message_bytes.iter())
-            .chain(crc.to_be_bytes().iter())
+            .chain(CHUNK_CRC.to_be_bytes().iter())
             .copied()
             .collect();
 
         let chunk = Chunk::try_from(chunk_data.as_ref()).unwrap();
 
         let chunk_string = chunk.data_as_string().unwrap();
-        let expected_chunk_string = String::from("This is where your secret message will be!");
+        let expected_chunk_string = String::from(CHUNK_MESSAGE);
 
         assert_eq!(chunk.length(), 42);
-        assert_eq!(chunk.chunk_type().to_string(), String::from("RuSt"));
+        assert_eq!(chunk.chunk_type().to_string(), String::from(CHUNK_STR));
         assert_eq!(chunk_string, expected_chunk_string);
-        assert_eq!(chunk.crc(), 2882656334);
+        assert_eq!(chunk.crc(), CHUNK_CRC);
     }
 
     #[test]
     fn test_invalid_chunk_from_bytes() {
-        let data_length: u32 = 42;
-        let chunk_type = "RuSt".as_bytes();
-        let message_bytes = "This is where your secret message will be!".as_bytes();
-        let crc: u32 = 2882656333;
+        let chunk_type = CHUNK_STR.as_bytes();
+        let message_bytes = CHUNK_MESSAGE.as_bytes();
+        let crc: u32 = CHUNK_CRC - 1;
 
-        let chunk_data: Vec<u8> = data_length
+        let chunk_data: Vec<u8> = CHUNK_DATA_LENGTH
             .to_be_bytes()
             .iter()
             .chain(chunk_type.iter())
@@ -106,17 +105,15 @@ mod tests {
 
     #[test]
     pub fn test_chunk_trait_impls() {
-        let data_length: u32 = 42;
-        let chunk_type = "RuSt".as_bytes();
-        let message_bytes = "This is where your secret message will be!".as_bytes();
-        let crc: u32 = 2882656334;
+        let chunk_type = CHUNK_STR.as_bytes();
+        let message_bytes = CHUNK_MESSAGE.as_bytes();
 
-        let chunk_data: Vec<u8> = data_length
+        let chunk_data: Vec<u8> = CHUNK_DATA_LENGTH
             .to_be_bytes()
             .iter()
             .chain(chunk_type.iter())
             .chain(message_bytes.iter())
-            .chain(crc.to_be_bytes().iter())
+            .chain(CHUNK_CRC.to_be_bytes().iter())
             .copied()
             .collect();
         

--- a/src/tests/chunk_tests.rs
+++ b/src/tests/chunk_tests.rs
@@ -2,7 +2,6 @@
 mod tests {
     use super::*;
     use crate::chunk_type::ChunkType;
-    use std::str::FromStr;
 
     fn testing_chunk() -> Chunk {
         let data_length: u32 = 42;
@@ -24,7 +23,7 @@ mod tests {
 
     #[test]
     fn test_new_chunk() {
-        let chunk_type = ChunkType::from_str("RuSt").unwrap();
+        let chunk_type: ChunkType = "RuSt".parse().unwrap();
         let data = "This is where your secret message will be!".as_bytes().to_vec();
         let chunk = Chunk::new(chunk_type, data);
         assert_eq!(chunk.length(), 42);

--- a/src/tests/chunk_type_tests.rs
+++ b/src/tests/chunk_type_tests.rs
@@ -1,8 +1,6 @@
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::convert::TryFrom;
-    use std::str::FromStr;
 
     #[test]
     pub fn test_chunk_type_from_bytes() {
@@ -15,83 +13,83 @@ mod tests {
     #[test]
     pub fn test_chunk_type_from_str() {
         let expected = ChunkType::try_from([82, 117, 83, 116]).unwrap();
-        let actual = ChunkType::from_str("RuSt").unwrap();
+        let actual: ChunkType = "RuSt".parse().unwrap();
         assert_eq!(expected, actual);
     }
 
     #[test]
     pub fn test_chunk_type_is_critical() {
-        let chunk = ChunkType::from_str("RuSt").unwrap();
+        let chunk: ChunkType = "RuSt".parse().unwrap();
         assert!(chunk.is_critical());
     }
 
     #[test]
     pub fn test_chunk_type_is_not_critical() {
-        let chunk = ChunkType::from_str("ruSt").unwrap();
+        let chunk: ChunkType = "ruSt".parse().unwrap();
         assert!(!chunk.is_critical());
     }
 
     #[test]
     pub fn test_chunk_type_is_public() {
-        let chunk = ChunkType::from_str("RUSt").unwrap();
+        let chunk: ChunkType = "RUSt".parse().unwrap();
         assert!(chunk.is_public());
     }
 
     #[test]
     pub fn test_chunk_type_is_not_public() {
-        let chunk = ChunkType::from_str("RuSt").unwrap();
+        let chunk: ChunkType = "RuSt".parse().unwrap();
         assert!(!chunk.is_public());
     }
 
     #[test]
     pub fn test_chunk_type_is_reserved_bit_valid() {
-        let chunk = ChunkType::from_str("RuSt").unwrap();
+        let chunk: ChunkType = "RuSt".parse().unwrap();
         assert!(chunk.is_reserved_bit_valid());
     }
 
     #[test]
     pub fn test_chunk_type_is_reserved_bit_invalid() {
-        let chunk = ChunkType::from_str("Rust").unwrap();
+        let chunk: ChunkType = "Rust".parse().unwrap();
         assert!(!chunk.is_reserved_bit_valid());
     }
 
     #[test]
     pub fn test_chunk_type_is_safe_to_copy() {
-        let chunk = ChunkType::from_str("RuSt").unwrap();
+        let chunk: ChunkType = "RuSt".parse().unwrap();
         assert!(chunk.is_safe_to_copy());
     }
 
     #[test]
     pub fn test_chunk_type_is_unsafe_to_copy() {
-        let chunk = ChunkType::from_str("RuST").unwrap();
+        let chunk: ChunkType = "RuST".parse().unwrap();
         assert!(!chunk.is_safe_to_copy());
     }
 
     #[test]
     pub fn test_valid_chunk_is_valid() {
-        let chunk = ChunkType::from_str("RuSt").unwrap();
+        let chunk: ChunkType = "RuSt".parse().unwrap();
         assert!(chunk.is_valid());
     }
 
     #[test]
     pub fn test_invalid_chunk_is_valid() {
-        let chunk = ChunkType::from_str("Rust").unwrap();
+        let chunk: ChunkType = "Rust".parse().unwrap();
         assert!(!chunk.is_valid());
 
-        let chunk = ChunkType::from_str("Ru1t");
+        let chunk: Result<ChunkType> = "Ru1t".parse();
         assert!(chunk.is_err());
     }
 
     #[test]
     pub fn test_chunk_type_string() {
-        let chunk = ChunkType::from_str("RuSt").unwrap();
+        let chunk: ChunkType = "RuSt".parse().unwrap();
         assert_eq!(&chunk.to_string(), "RuSt");
     }
 
     #[test]
     pub fn test_chunk_type_trait_impls() {
-        let chunk_type_1: ChunkType = TryFrom::try_from([82, 117, 83, 116]).unwrap();
-        let chunk_type_2: ChunkType = FromStr::from_str("RuSt").unwrap();
+        let chunk_type_1: ChunkType = [82, 117, 83, 116].try_into().unwrap();
+        let chunk_type_2: ChunkType = "RuSt".parse().unwrap();
         let _chunk_string = format!("{}", chunk_type_1);
         let _are_chunks_equal = chunk_type_1 == chunk_type_2;
     }

--- a/src/tests/chunk_type_tests.rs
+++ b/src/tests/chunk_type_tests.rs
@@ -4,22 +4,22 @@ mod tests {
 
     #[test]
     pub fn test_chunk_type_from_bytes() {
-        let expected = [82, 117, 83, 116];
-        let actual = ChunkType::try_from([82, 117, 83, 116]).unwrap();
+        let expected = [114, 85, 83, 116];
+        let actual = ChunkType::try_from(expected).unwrap();
 
         assert_eq!(expected, actual.bytes());
     }
 
     #[test]
     pub fn test_chunk_type_from_str() {
-        let expected = ChunkType::try_from([82, 117, 83, 116]).unwrap();
-        let actual: ChunkType = "RuSt".parse().unwrap();
+        let expected = ChunkType::try_from([114, 85, 83, 116]).unwrap();
+        let actual: ChunkType = "rUSt".parse().unwrap();
         assert_eq!(expected, actual);
     }
 
     #[test]
     pub fn test_chunk_type_is_critical() {
-        let chunk: ChunkType = "RuSt".parse().unwrap();
+        let chunk: ChunkType = "RUSt".parse().unwrap();
         assert!(chunk.is_critical());
     }
 
@@ -31,19 +31,19 @@ mod tests {
 
     #[test]
     pub fn test_chunk_type_is_public() {
-        let chunk: ChunkType = "RUSt".parse().unwrap();
+        let chunk: ChunkType = "rUSt".parse().unwrap();
         assert!(chunk.is_public());
     }
 
     #[test]
     pub fn test_chunk_type_is_not_public() {
-        let chunk: ChunkType = "RuSt".parse().unwrap();
+        let chunk: ChunkType = "ruSt".parse().unwrap();
         assert!(!chunk.is_public());
     }
 
     #[test]
     pub fn test_chunk_type_is_reserved_bit_valid() {
-        let chunk: ChunkType = "RuSt".parse().unwrap();
+        let chunk: ChunkType = "rUSt".parse().unwrap();
         assert!(chunk.is_reserved_bit_valid());
     }
 
@@ -55,7 +55,7 @@ mod tests {
 
     #[test]
     pub fn test_chunk_type_is_safe_to_copy() {
-        let chunk: ChunkType = "RuSt".parse().unwrap();
+        let chunk: ChunkType = "rUSt".parse().unwrap();
         assert!(chunk.is_safe_to_copy());
     }
 
@@ -67,29 +67,41 @@ mod tests {
 
     #[test]
     pub fn test_valid_chunk_is_valid() {
-        let chunk: ChunkType = "RuSt".parse().unwrap();
+        let chunk: ChunkType = "rUSt".parse().unwrap();
+        assert!(chunk.is_valid());
+
+        let chunk: ChunkType = "RuST".parse().unwrap();
         assert!(chunk.is_valid());
     }
 
     #[test]
-    pub fn test_invalid_chunk_is_valid() {
-        let chunk: ChunkType = "Rust".parse().unwrap();
-        assert!(!chunk.is_valid());
-
-        let chunk: Result<ChunkType> = "Ru1t".parse();
+    pub fn test_invalid_character() {
+        let chunk: Result<ChunkType> = "r1St".parse();
         assert!(chunk.is_err());
     }
 
     #[test]
-    pub fn test_chunk_type_string() {
+    pub fn test_invalid_reserved() {
+        let chunk: ChunkType = "rUst".parse().unwrap();
+        assert!(!chunk.is_valid());
+    }
+
+    #[test]
+    pub fn test_invalid_safetocopy() {
         let chunk: ChunkType = "RuSt".parse().unwrap();
-        assert_eq!(&chunk.to_string(), "RuSt");
+        assert!(!chunk.is_valid());
+    }
+
+    #[test]
+    pub fn test_chunk_type_string() {
+        let chunk: ChunkType = "rUSt".parse().unwrap();
+        assert_eq!(&chunk.to_string(), "rUSt");
     }
 
     #[test]
     pub fn test_chunk_type_trait_impls() {
         let chunk_type_1: ChunkType = [82, 117, 83, 116].try_into().unwrap();
-        let chunk_type_2: ChunkType = "RuSt".parse().unwrap();
+        let chunk_type_2: ChunkType = "rUSt".parse().unwrap();
         let _chunk_string = format!("{}", chunk_type_1);
         let _are_chunks_equal = chunk_type_1 == chunk_type_2;
     }

--- a/src/tests/png_tests.rs
+++ b/src/tests/png_tests.rs
@@ -6,9 +6,9 @@ mod tests {
 
     fn testing_chunks() -> Vec<Chunk> {
         vec![
-            chunk_from_strings("FrSt", "I am the first chunk").unwrap(),
+            chunk_from_strings("FrST", "I am the first chunk").unwrap(),
             chunk_from_strings("miDl", "I am another chunk").unwrap(),
-            chunk_from_strings("LASt", "I am the last chunk").unwrap(),
+            chunk_from_strings("lAST", "I am the last chunk").unwrap(),
         ]
     }
 
@@ -106,26 +106,26 @@ mod tests {
     #[test]
     fn test_chunk_by_type() {
         let png = testing_png();
-        let chunk = png.chunk_by_type("FrSt").unwrap();
-        assert_eq!(&chunk.chunk_type().to_string(), "FrSt");
+        let chunk = png.chunk_by_type("FrST").unwrap();
+        assert_eq!(&chunk.chunk_type().to_string(), "FrST");
         assert_eq!(&chunk.data_as_string().unwrap(), "I am the first chunk");
     }
 
     #[test]
     fn test_append_chunk() {
         let mut png = testing_png();
-        png.append_chunk(chunk_from_strings("TeSt", "Message").unwrap());
-        let chunk = png.chunk_by_type("TeSt").unwrap();
-        assert_eq!(&chunk.chunk_type().to_string(), "TeSt");
+        png.append_chunk(chunk_from_strings("teSt", "Message").unwrap());
+        let chunk = png.chunk_by_type("teSt").unwrap();
+        assert_eq!(&chunk.chunk_type().to_string(), "teSt");
         assert_eq!(&chunk.data_as_string().unwrap(), "Message");
     }
 
     #[test]
     fn test_remove_chunk() {
         let mut png = testing_png();
-        png.append_chunk(chunk_from_strings("TeSt", "Message").unwrap());
-        png.remove_chunk("TeSt").unwrap();
-        let chunk = png.chunk_by_type("TeSt");
+        png.append_chunk(chunk_from_strings("teSt", "Message").unwrap());
+        png.remove_chunk("teSt").unwrap();
+        let chunk = png.chunk_by_type("teSt");
         assert!(chunk.is_none());
     }
 

--- a/src/tests/png_tests.rs
+++ b/src/tests/png_tests.rs
@@ -3,8 +3,6 @@ mod tests {
     use super::*;
     use crate::chunk::Chunk;
     use crate::chunk_type::ChunkType;
-    use std::convert::TryFrom;
-    use std::str::FromStr;
 
     fn testing_chunks() -> Vec<Chunk> {
         vec![
@@ -20,9 +18,7 @@ mod tests {
     }
 
     fn chunk_from_strings(chunk_type: &str, data: &str) -> Result<Chunk> {
-        use std::str::FromStr;
-
-        let chunk_type = ChunkType::from_str(chunk_type)?;
+        let chunk_type: ChunkType = chunk_type.parse()?;
         let data: Vec<u8> = data.bytes().collect();
 
         Ok(Chunk::new(chunk_type, data))
@@ -160,7 +156,8 @@ mod tests {
             .copied()
             .collect();
 
-        let png: Png = TryFrom::try_from(bytes.as_ref()).unwrap();
+        let bytes_ref: &[u8] = bytes.as_ref();
+        let png: Png = bytes_ref.try_into().unwrap();
 
         let _png_string = format!("{}", png);
     }

--- a/src/tests/png_tests.rs
+++ b/src/tests/png_tests.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chunk_type::ChunkType;
     use crate::chunk::Chunk;
-    use std::str::FromStr;
+    use crate::chunk_type::ChunkType;
     use std::convert::TryFrom;
+    use std::str::FromStr;
 
     fn testing_chunks() -> Vec<Chunk> {
         vec![
@@ -89,11 +89,16 @@ mod tests {
 
         chunk_bytes.append(&mut bad_chunk);
 
-        let png = Png::try_from(chunk_bytes.as_ref());
+        let bytes: Vec<u8> = Png::STANDARD_HEADER
+            .iter()
+            .chain(chunk_bytes.iter())
+            .copied()
+            .collect();
+
+        let png = Png::try_from(bytes.as_ref());
 
         assert!(png.is_err());
     }
-
 
     #[test]
     fn test_list_chunks() {
@@ -108,7 +113,6 @@ mod tests {
         let chunk = png.chunk_by_type("FrSt").unwrap();
         assert_eq!(&chunk.chunk_type().to_string(), "FrSt");
         assert_eq!(&chunk.data_as_string().unwrap(), "I am the first chunk");
-
     }
 
     #[test]

--- a/util/update_code
+++ b/util/update_code
@@ -1,0 +1,38 @@
+#! /bin/sh
+
+code_src=${1:-code/src}
+
+[ -d ".git" -a -r "book.toml" -a -r "src/tests/chunk_type_tests.rs" ] \
+  || { echo "Run this from the top level of the sources" >&2; exit 2; }
+
+[ -r "$code_src/chunk_type.rs" ] \
+  || { echo "Can't find sources in '$code_src'" >&2; exit 2; }
+
+if [ $# -eq 0 ]; then
+  for stubs in src/stubs/*_full.rs src/stubs/*_stubs.rs; do
+    base=$(basename "$stubs")
+    base=${base%_full.rs}
+    base=${base%_stubs.rs}
+    out=$code_src/$base.rs
+    echo "Setting $out to $stubs"
+    cp "$stubs" "$out"
+    if [ -r src/tests/${base}_tests.rs ]; then
+      printf "\n%s\n" '#[cfg(test)]' >> "$out"
+    fi
+  done
+fi
+
+for tests in src/tests/*_tests.rs; do
+  base=$code_src/$(basename "$tests")
+  base=${base%_tests.rs}
+  out=$base.rs
+  echo "Updating $out with $tests"
+  sed -i -n \
+    "
+      /^#\[cfg(test)]/ {
+        r $tests
+        q
+      }
+      p
+    " "$out"
+  done


### PR DESCRIPTION
The PNG spec states "the safe-to-copy bit will always be 0 for critical
chunks". All of the tests should respect this. One test has been added
to ensure this (`chunk_type::test_invalid_safetocopy`).

This required changing many tests, as they used `"RuSt"`, which is not
a valid chunk type.

This PR is built on top of #16. If that PR is rejected, I can rework this to
match the project's goals, just let me know what's wanted.

Fixes #11.