### PR TITLE
Rename `remove_chunk` to `remove_first_chunk`

### DIFF
--- a/code/src/png.rs
+++ b/code/src/png.rs
@@ -38,7 +38,7 @@ impl Png {
 
     /// Searches for a `Chunk` with the specified `chunk_type` and removes the first
     /// matching `Chunk` from this `Png` list of chunks.
-    pub fn remove_chunk(&mut self, chunk_type: &str) -> Result<Chunk> {
+    pub fn remove_first_chunk(&mut self, chunk_type: &str) -> Result<Chunk> {
         todo!()
     }
 
@@ -200,10 +200,10 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_chunk() {
+    fn test_remove_first_chunk() {
         let mut png = testing_png();
         png.append_chunk(chunk_from_strings("TeSt", "Message").unwrap());
-        png.remove_chunk("TeSt").unwrap();
+        png.remove_first_chunk("TeSt").unwrap();
         let chunk = png.chunk_by_type("TeSt");
         assert!(chunk.is_none());
     }

--- a/src/chapter_3.md
+++ b/src/chapter_3.md
@@ -27,7 +27,7 @@ You need to provide a constructor that takes a list of chunks, methods to append
 6. Required methods:
    1. `fn from_chunks(chunks: Vec<Chunk>) -> Png`
    2. `fn append_chunk(&mut self, chunk: Chunk)`
-   3. `fn remove_chunk(&mut self, chunk_type: &str) -> Result<Chunk>`
+   3. `fn remove_first_chunk(&mut self, chunk_type: &str) -> Result<Chunk>`
    4. `fn header(&self) -> &[u8; 8]`
    5. `fn chunks(&self) -> &[Chunk]`
    6. `fn chunk_by_type(&self, chunk_type: &str) -> Option<&Chunk>`

--- a/src/stubs/png_stubs.rs
+++ b/src/stubs/png_stubs.rs
@@ -37,7 +37,7 @@ impl Png {
 
     /// Searches for a `Chunk` with the specified `chunk_type` and removes the first
     /// matching `Chunk` from this `Png` list of chunks.
-    pub fn remove_chunk(&mut self, chunk_type: &str) -> Result<Chunk> {
+    pub fn remove_first_chunk(&mut self, chunk_type: &str) -> Result<Chunk> {
         todo!()
     }
 

--- a/src/tests/png_tests.rs
+++ b/src/tests/png_tests.rs
@@ -121,10 +121,10 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_chunk() {
+    fn test_remove_first_chunk() {
         let mut png = testing_png();
         png.append_chunk(chunk_from_strings("TeSt", "Message").unwrap());
-        png.remove_chunk("TeSt").unwrap();
+        png.remove_first_chunk("TeSt").unwrap();
         let chunk = png.chunk_by_type("TeSt");
         assert!(chunk.is_none());
     }


### PR DESCRIPTION
The current name can be confusing to people following the book as there is ambiguity in the possible implementation if they don't look at the comments provided in the hint stub.