### PR TITLE
Mark code as no_run

### DIFF
--- a/src/chapter_1.md
+++ b/src/chapter_1.md
@@ -44,7 +44,7 @@ You will also need to implement a few standard library traits.
 
 ## Unit Tests
 
-```rust
+```rust,no_run
 {{#include tests/chunk_type_tests.rs}}
 ```
 


### PR DESCRIPTION
mdBook wraps a main around the included code so that it might be run on the playground, but that extra code is also copied when pressing the copy button. An alternative to no_run is noplayground (https://rust-lang.github.io/mdBook/format/mdbook.html#rust-code-block-attributes), or both although that seems redundant, but is what the mdbook docs uses for its example (https://rust-lang.github.io/mdBook/format/mdbook.html#including-portions-of-a-file).