### PR TITLE
Update mdbook to 4.40

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Downloading mdbook
         run: >
           wget -q -O - 
-          "https://github.com/rust-lang/mdBook/releases/download/v0.3.7/mdbook-v0.3.7-x86_64-unknown-linux-gnu.tar.gz" 
+          "https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz"
           | sudo tar xzf - -C /usr/local/bin
       - name: Configure git
         run: git config --global user.email "github-actions-bot@users.noreply.github.com" && git config --global user.name  "GitHub Actions"


### PR DESCRIPTION
Moves to a version after the renaming of playpen to playground, such that noplayground should work.